### PR TITLE
Fixing broken recipe dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   run:
     - conda
     - python >=3.7
-    - art
+    - sympy
 
 about:
   home: https://github.com/conda/conda-plugin-template


### PR DESCRIPTION
Looks like we forgot to update the recipe with the appropriate dependencies for the example.