### PR TITLE
Url change: plugin-api -> plugins

### DIFF
--- a/tutorials/subcommands/c/README.md
+++ b/tutorials/subcommands/c/README.md
@@ -5,7 +5,7 @@
 [build conda packages]: https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs.html
 [upload to anaconda.org]: https://docs.anaconda.com/anacondaorg/user-guide/tasks/work-with-packages/#uploading-packages
 [anaconda.org site]: https://anaconda.org/
-[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugin-api/index.html#a-note-on-licensing
+[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugins/index.html#a-note-on-licensing
 [cffi docs]: https://cffi.readthedocs.io/en/latest/overview.html#main-mode-of-usage
 [pep 621]: https://peps.python.org/pep-0621/
 [pluggy docs]: https://pluggy.readthedocs.io/en/stable/index.html

--- a/tutorials/subcommands/python/README.md
+++ b/tutorials/subcommands/python/README.md
@@ -6,7 +6,7 @@
 [upload to anaconda.org]: https://docs.anaconda.com/anacondaorg/user-guide/tasks/work-with-packages/#uploading-packages
 [anaconda.org site]: https://anaconda.org/
 [pluggy docs]: https://pluggy.readthedocs.io/en/stable/index.html
-[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugin-api/index.html#a-note-on-licensing
+[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugins/index.html#a-note-on-licensing
 [pep 621]: https://peps.python.org/pep-0621/
 [setup.py docs]: https://docs.python.org/3/distutils/setupscript.html
 

--- a/tutorials/subcommands/rust/README.md
+++ b/tutorials/subcommands/rust/README.md
@@ -7,7 +7,7 @@
 [build conda packages]: https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs.html
 [upload to anaconda.org]: https://docs.anaconda.com/anacondaorg/user-guide/tasks/work-with-packages/#uploading-packages
 [anaconda.org site]: https://anaconda.org/
-[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugin-api/index.html#a-note-on-licensing
+[licenses]: https://docs.conda.io/projects/conda/en/latest/dev-guide/plugins/index.html#a-note-on-licensing
 [pep 621]: https://peps.python.org/pep-0621/
 [maturin]: https://github.com/PyO3/maturin
 [pyo3]: https://github.com/PyO3/pyo3


### PR DESCRIPTION
Recently plugin-api was moved to plugins, and existing urls are 404ing pending a permission impaired redirect change.